### PR TITLE
Add a .clangd to prevent errors regarding unsupported compiler flags …

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,6 @@
+CompileFlags:
+    Remove: [-fno-shrink-wrap, -fstrict-volatile-bitfields, -fno-tree-switch-conversion, -march=rv32imafc_zicsr_zifencei_xesppie]
+
+
+Index:
+  StandardLibrary: No


### PR DESCRIPTION
Basic Clangd configuration, to make sure line 1 of C files doesn't contain errors caused by the Clangd not parsing optimization flags correctly.